### PR TITLE
Tell AutoDoc to process the bibliography.

### DIFF
--- a/makedoc.g
+++ b/makedoc.g
@@ -15,6 +15,7 @@ AutoDoc(rec(
             "examples.xml",
             "functionality.xml",
         ],
+        bib := "smallsemi.bib",
     ),
     gapdoc := rec( main := "smallsemi.xml" ),
     extract_examples := true,


### PR DESCRIPTION
I tried to build version 0.6.12 for Fedora Rawhide, with gap 4.10.2 and AutoDoc 2019.07.24, and saw this in the build logs:

```
#I Producing the index . . .
#I Writing bibliography . . .
Error, Record Element: '<rec>.bibentries' must have an assigned value in
  need := List( r.bibentries, function ( a )
        return RecBibXMLEntry( a, "Text", r.bibstrings );
    end ); at /usr/lib/gap/pkg/GAPDoc/lib/GAPDoc2Text.gi:597 called from 
GAPDoc2TextProcs.(r.name)( r, str 
 ); at /usr/lib/gap/pkg/GAPDoc/lib/GAPDoc2Text.gi:380 called from
GAPDoc2Text( r, path ) at /usr/lib/gap/pkg/GAPDoc/lib/Make.g:48 called from
CallFuncList( makeDocFun, args ); at /usr/lib/gap/pkg/AutoDoc/gap/Magic.gi:575 called from
<function "AutoDoc">( <arguments> )
 called from read-eval loop at makedoc.g:21
you can 'return;' after assigning a value
gap> brk> Reading file "makedoc.g" has been aborted.
```

This commit tells AutoDoc to process the bibliography, thereby fixing the problem.  Fix tested in Fedora Rawhide.