### PR TITLE
Accommodate future changed ViewStrings in GAP

### DIFF
--- a/tst/small.tst
+++ b/tst/small.tst
@@ -23,8 +23,7 @@ gap> sgrp := SemigroupByMultiplicationTable([[1]]);;
 gap> map:=EquivalenceSmallSemigroup(sgrp);;
 gap> Size(Range(map));
 1
-gap> grp:=SmallGroup(7,1);
-<pc group of size 7 with 1 generators>
+gap> grp:=SmallGroup(7,1);;
 gap> map:=EquivalenceSmallSemigroup(grp); 
 SemigroupHomomorphismByImages ( Group( [ f1 ] )-><small semigroup of size 7>)
 gap> id:=IdSmallSemigroup(Range(map));


### PR DESCRIPTION
Due to gap-system/gap#3992, phrases like "1 generators" in ViewStrings of GAP objects will soon instead be correctly pluralised as "1 generator". I think this PR changes the only test that would be affected by this change. As far as I can tell, manual examples are not affected.