### PR TITLE
Add comment to declaration of `MinimalGeneratingSet`

### DIFF
--- a/gap/properties.gd
+++ b/gap/properties.gd
@@ -978,7 +978,8 @@ DeclareProperty("IsSingularSemigroupCopy", IsSmallSemigroup);
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
-
+# MinimalGeneratingSet was only declared for IsGroup in GAP < 4.12. This
+# declaration and comment can be removed if smallsemi ever requires GAP >= 4.12.
 DeclareAttribute("MinimalGeneratingSet", IsSemigroup);
 
 ###########################################################################


### PR DESCRIPTION
In GAP versions before GAP 4.12, `MinimalGeneratingSet` is only declared in the GAP library for `IsGroup`. This means that we have to separately declare it for `IsSemigroup`. This then gives warnings when further methods are installed for `IsGroup`, because they don't know which declaration they belong to. Not a huge problem, but one with an easy fix.

The GAP master branch does, and GAP 4.12 will, declare `MinimalGeneratingSet` for `IsSemigroup` instead; see https://github.com/gap-system/gap/pull/4329. ~~Therefore we should only make this declaration when GAP has not already made it. Eventually, the package will presumably require a new enough GAP version that all of this code can be deleted, but I do not yet know which version of GAP that would be.~~

There is no harm in re-declaring an attribute, so let's just leave it in, but with a comment that we can remove the declaration if smallsemi ever requires GAP 4.12 or newer.

See also https://github.com/semigroups/Semigroups/pull/756.