### PR TITLE
Switch to two argument version of ReadPackage

### DIFF
--- a/init.g
+++ b/init.g
@@ -8,12 +8,12 @@
 #############################################################################
 ##
 
-ReadPackage("smallsemi/gap/small.gd");
-ReadPackage("smallsemi/gap/properties.gd");
-ReadPackage("smallsemi/gap/enums.gd");
-ReadPackage("smallsemi/gap/utils.gd");
-ReadPackage("smallsemi/gap/greensstar.gd");
-ReadPackage("smallsemi/gap/coclass.gd");
+ReadPackage("smallsemi", "gap/small.gd");
+ReadPackage("smallsemi", "gap/properties.gd");
+ReadPackage("smallsemi", "gap/enums.gd");
+ReadPackage("smallsemi", "gap/utils.gd");
+ReadPackage("smallsemi", "gap/greensstar.gd");
+ReadPackage("smallsemi", "gap/coclass.gd");
 
 DeclareAutoreadableVariables( "smallsemi", "gap/autovars.g",
                               [ "MOREDATA2TO8",

--- a/read.g
+++ b/read.g
@@ -8,10 +8,9 @@
 #############################################################################
 ##
 
-ReadPackage("smallsemi/gap/small.gi");
-ReadPackage("smallsemi/gap/properties.gi");
-ReadPackage("smallsemi/gap/enums.gi");
-ReadPackage("smallsemi/gap/utils.gi");
-ReadPackage("smallsemi/gap/greensstar.gi");
-ReadPackage("smallsemi/gap/coclass.gi");
-
+ReadPackage("smallsemi", "gap/small.gi");
+ReadPackage("smallsemi", "gap/properties.gi");
+ReadPackage("smallsemi", "gap/enums.gi");
+ReadPackage("smallsemi", "gap/utils.gi");
+ReadPackage("smallsemi", "gap/greensstar.gi");
+ReadPackage("smallsemi", "gap/coclass.gi");


### PR DESCRIPTION
The one argument form is not recommended, as it just has to split
the string into two anyway, and the input looks like a path, but
it isn't really, as the first part is a pacakge name, not a
directory name...
