### PR TITLE
Turn BLUEPRINT_MATS into a function

### DIFF
--- a/gap/autovars.g
+++ b/gap/autovars.g
@@ -26,27 +26,6 @@
 # <#/GAPDoc>
 BindGlobal("MOREDATA2TO8", READ_MOREDATA2TO8());
 
-# <#GAPDoc Label="BLUEPRINT_MATS">
-# <ManSection>
-# <Var Name="BLUEPRINT_MATS"/>
-# <Description>
-# see <Ref Func="GENERATE_BLUEPRINT_MATS"/>.
-# <Example><![CDATA[
-# gap> Display(BLUEPRINT_MATS[3]);
-# [ [  1,  1,  1,  1,  1,  1,  1,  1 ],
-#   [  1,  1,  1,  1,  1,  1,  1,  1 ],
-#   [  1,  1,  1,  1,  1,  1,  1,  1 ],
-#   [  1,  1,  1 ],
-#   [  1,  1,  1 ],
-#   [  1,  1,  1 ],
-#   [  1,  1,  1 ],
-#   [  1,  1,  1 ] ]
-# ]]></Example>
-# </Description>
-# </ManSection>
-# <#/GAPDoc>
-BindGlobal("BLUEPRINT_MATS", GENERATE_BLUEPRINT_MATS());
-
 # <#GAPDoc Label="PrecomputedSmallSemisInfo">
 # <ManSection>
 # <Var Name="PrecomputedSmallSemisInfo"/>

--- a/gap/small.gd
+++ b/gap/small.gd
@@ -326,17 +326,27 @@ DeclareGlobalVariable("DATA8", "raw data for semigroup tables size 8");
 ## INTERNAL FUNCTIONS ##
 ########################
 
-# <#GAPDoc Label="GENERATE_BLUEPRINT_MATS">
+# <#GAPDoc Label="BLUEPRINT_MATS">
 # <ManSection>
-# <Func Name="GENERATE_BLUEPRINT_MATS" Arg=""/>
+# <Func Name="BLUEPRINT_MATS" Arg="k"/>
 # <Description>
-# generates a list of matrices bound for k in <M>\{2,...,7\}</M> such
-# that the k-th entry has k 'zero' rows and columns. To be stored in the
-# variable <C>BLUEPRINT_MATS</C>.
+# generates matrix for <A>k</A> in <M>\{2,...,7\}</M> such
+# that the <A>k</A>-th entry has <A>k</A> 'zero' rows and columns.
+# <Example><![CDATA[
+# gap> Display(BLUEPRINT_MATS(3));
+# [ [  1,  1,  1,  1,  1,  1,  1,  1 ],
+#   [  1,  1,  1,  1,  1,  1,  1,  1 ],
+#   [  1,  1,  1,  1,  1,  1,  1,  1 ],
+#   [  1,  1,  1 ],
+#   [  1,  1,  1 ],
+#   [  1,  1,  1 ],
+#   [  1,  1,  1 ],
+#   [  1,  1,  1 ] ]
+# ]]></Example>
 # </Description>
 # </ManSection>
 # <#/GAPDoc>
-DeclareGlobalFunction("GENERATE_BLUEPRINT_MATS");
+DeclareGlobalFunction("BLUEPRINT_MATS");
 
 # <#GAPDoc Label="READ_3NIL_DATA">
 # <ManSection>

--- a/gap/small.gi
+++ b/gap/small.gi
@@ -381,7 +381,7 @@ function(size, nr)
         int := SMALLSEMI_BinInt(line, 8 - m);
         int := int + (nr - 3NIL_DATA.positions[pos]);
 
-        mat := StructuralCopy(BLUEPRINT_MATS[8 - m]);
+        mat := BLUEPRINT_MATS(8 - m);
 
         # based on 'IntBit' but putting values directly into matrix
         for i in [1 .. m] do
@@ -512,10 +512,6 @@ InstallGlobalFunction(UnloadSmallsemiData, function(uselater)
   # unbind data essential for the use of smallsemi
   if not uselater then
 
-    for pos in [2 .. 7] do
-      Unbind(BLUEPRINT_MATS[pos]);
-    od;
-
     # unbind data records from info files
     for pos in [1 .. 8] do
       Unbind(MOREDATA2TO8[pos]);
@@ -536,24 +532,22 @@ InstallFlushableValue(DATA8, []);
 # INTERNAL FUNCTIONS
 #############################################################################
 
-InstallGlobalFunction(GENERATE_BLUEPRINT_MATS, function()
-  local mats, k, i;
+InstallGlobalFunction(BLUEPRINT_MATS, function(k)
+  local mat, i;
+  Assert(0, k in [2 .. 8]);
 
-  mats := EmptyPlist(7);
-  for k in [2 .. 7] do
-    # size 8 matrix
-    mats[k] := EmptyPlist(8);
-    # first k zero rows (the zero is '1')
-    for i in [1 .. k] do
-      mats[k][i] := ListWithIdenticalEntries(8, 1);
-    od;
-    # zero columns (the zero is '1')
-    for i in [k + 1 .. 8] do
-      mats[k][i] := ListWithIdenticalEntries(k, 1);
-    od;
+  # size 8 matrix
+  mat := EmptyPlist(8);
+  # first k zero rows (the zero is '1')
+  for i in [1 .. k] do
+    mat[i] := ListWithIdenticalEntries(8, 1);
+  od;
+  # zero columns (the zero is '1')
+  for i in [k + 1 .. 8] do
+    mat[i] := ListWithIdenticalEntries(k, 1);
   od;
 
-  return mats;
+  return mat;
 end);
 
 InstallGlobalFunction(READ_3NIL_DATA, function(diag)

--- a/init.g
+++ b/init.g
@@ -18,5 +18,4 @@ ReadPackage("smallsemi", "gap/3nil.gd");
 
 DeclareAutoreadableVariables("smallsemi", "gap/autovars.g",
                              ["MOREDATA2TO8",
-                              "PrecomputedSmallSemisInfo",
-                              "BLUEPRINT_MATS"]);
+                              "PrecomputedSmallSemisInfo"]);

--- a/tst/small.tst
+++ b/tst/small.tst
@@ -107,7 +107,7 @@ gap> DATA2TO7;
 [  ]
 gap> DATA8;
 [  ]
-gap> Display(BLUEPRINT_MATS[3]);
+gap> Display(BLUEPRINT_MATS(3));
 [ [  1,  1,  1,  1,  1,  1,  1,  1 ],
   [  1,  1,  1,  1,  1,  1,  1,  1 ],
   [  1,  1,  1,  1,  1,  1,  1,  1 ],

--- a/tst/smallsemi02.tst
+++ b/tst/smallsemi02.tst
@@ -695,7 +695,7 @@ gap> PositionsOfSmallSemigroups(enum, Is1IdempotentSemigroup, true,
 > Is2GeneratedSemigroup, true, IsCliffordSemigroup, false);
 [ [ 1, 2 ] ]
 
-# doc/../gap/autovars.g:58-69
+# doc/../gap/autovars.g:37-48
 gap> PrecomputedSmallSemisInfo[3];
 [ "Is2GeneratedSemigroup", "Is3GeneratedSemigroup", "Is4GeneratedSemigroup",
   "Is5GeneratedSemigroup", "Is6GeneratedSemigroup", "Is7GeneratedSemigroup",


### PR DESCRIPTION
... instead of it being an autoreadable variable.

Better than to allow cleaning a cache is to never even need it :-).

Overall I am on a minor quest to expunge all uses of autoreadable
variables so that perhaps one day we can sunset this GAP feature (or at
least: have to worry less about this somewhat obscure and exotic feature
when reasoning about code).

I think the two remaining autoreadable variables could also be turned
into regular variables as well, by letting access through them go
through a helper function which loads the missing data on demand.

However, those two other variables are documented and I am not sure
whether you think keeping access to them is important or not. E.g. if
you have tons of internal code that directly accesses `MOREDATA2TO8` and
`PrecomputedSmallSemisInfo` then maybe you don't want to change that.

(One could solve this by introducing an `AutoReadList` or `LazyList`
type which computes and caches its entries lazily. I am not suggesting
you do this here)