### PR TITLE
Make RandomSmallSemigroup random

### DIFF
--- a/doc/functionality.xml
+++ b/doc/functionality.xml
@@ -217,8 +217,7 @@ semigroup. Then
     <Ref Func="IteratorOfSmallSemigroups"/>,
     <Ref Func="NrSmallSemigroups"/>,
     <Ref Func="OneSmallSemigroup"/>,
-    <Ref Func="PositionsOfSmallSemigroups"/>,
-	<Ref Func="RandomSmallSemigroup"/>. <P/>
+    <Ref Func="PositionsOfSmallSemigroups"/>. <P/>
 
 	The number of arguments should be odd:
 	<List>
@@ -313,9 +312,9 @@ semigroup. Then
 	<#Include Label="PositionsOfSmallSemigroupsIn">
 	<#Include Label="PositionsOfSmallSemigroups">
 	<#Include Label="PrecomputedSmallSemisInfo">
-	<#Include Label="RandomSmallSemigroup">
 	<#Include Label="SizesOfSmallSemigroupsIn">
 	<#Include Label="UpToIsomorphism">
+	<#Include Label="RandomSmallSemigroup">
 
 </Section>
 </Chapter>

--- a/gap/enums.gd
+++ b/gap/enums.gd
@@ -512,38 +512,54 @@ DeclareGlobalFunction("PositionsOfSmallSemigroups");
 # <ManSection>
 # <Func Name="RandomSmallSemigroup" Arg="arg"/>
 # <Description>
-# the number of argument of this function should be odd. The first argument
-# <C>arg[1]</C> should be a positive integer, an enumerator of small semigroups
-# with <Ref Func="IsEnumeratorOfSmallSemigroups"/>, or an iterator of small
-# semigroup with <Ref Func="IsIteratorOfSmallSemigroups"/>.
+# this function differs from the other functions in this section in that
+# it need not necessarily have an odd number of arguments. It optionally
+# can take a random source as the first argument (see <Ref BookName="ref"
+# Sect="Random Sources"/>).
+# <P/>
+# If the first argument <C>arg[1]</C> is a random source, then it is used to
+# drive the randomness in selecting the semigroup. This is useful for
+# reproducible results using a fixed random source or stronger randomness using
+# a <C>RealRandomSource</C> (see <Ref BookName="io" Sect=
+# "Really random source"/>).
+# <P/>
+# The remaining arguments follow the same pattern as
+# the rest of the functions in this section. That is,
+# following the optional random source, the remaining number of arguments
+# should be odd. For ease of notation, we define the offset <C>k:=1</C>
+# if no random source is given, and <C>k:=2</C> otherwise.
+# The argument <C>arg[k]</C> should be a positive integer, an enumerator of
+# small semigroups with <Ref Func="IsEnumeratorOfSmallSemigroups"/>, or an
+# iterator of small semigroups with <Ref Func="IsIteratorOfSmallSemigroups"/>.
 # <P/>
 #
-# The even arguments <C>arg[2i]</C>, if present, should be functions, and the
-# odd arguments <C>arg[2i+1]</C> should be a value that the preceding function
-# can have. For example, a typical input might be <C>3, IsRegularSemigroup,
-# true</C>. The functions <C>arg[2i]</C> can be user defined or existing &GAP;
-# functions.
+# The arguments <C>arg[k+2i-1]</C>,
+# if present, should be functions, and the arguments <C>arg[k+2i]</C>
+# should be a value that the preceding function can have. For example, a
+# typical input might be <C>3, IsRegularSemigroup, true</C>. The functions
+# <C>arg[k+2i-1]</C> can be user defined or existing &GAP; functions.
 # <P/>
 #
 # Please see Section <Ref Sect="enums"/> or Chapter <Ref Chap="examples"/> for
 # more details.
 # <P/>
 #
-# If <C>arg[1]</C> is a positive integer, then <C>RandomSmallSemigroup</C>
+# If <C>arg[k]</C> is a positive integer, then <C>RandomSmallSemigroup</C>
 # returns a random small semigroup <C>S</C> in the library with
-# <C>Size(S)=arg[1]</C> and <C>arg[2i](S)=arg[2i+1]</C> for all <C>i</C>.
-# <P/>
-#
-# If <C>arg[1]</C> is a list of positive integers, then
-# <C>RandomSmallSemigroup</C> returns the a random small semigroup <C>S</C> in
-# the library with <C>Size(S) in arg[1]</C> and <C>arg[2i](S)=arg[2i+1]</C> for
-# all <C>i</C>.
-# <P/>
-#
-# If <C>arg[1]</C> is an enumerator or iterator of small semigroups, then
-# <C>RandomSmallSemigroup</C> returns the a random small semigroup <C>S</C> in
-# the library with <C>S in arg[1]</C> and <C>arg[2i](S)=arg[2i+1]</C> for all
+# <C>Size(S)=arg[k]</C> and <C>arg[k+2i-1](S)=arg[k+2i]</C> for all
 # <C>i</C>.
+# <P/>
+#
+# If <C>arg[k]</C> is a list of positive integers, then
+# <C>RandomSmallSemigroup</C> returns the a random small semigroup <C>S</C> in
+# the library with <C>Size(S) in arg[k]</C> and <C>arg[k+2i-1](S)=arg[k+2i]
+# </C> for all <C>i</C>.
+# <P/>
+#
+# If <C>arg[k]</C> is an enumerator or iterator of small semigroups, then
+# <C>RandomSmallSemigroup</C> returns the a random small semigroup <C>S</C> in
+# the library with <C>S in arg[k]</C> and <C>arg[k+2i-1](S)=arg[k+2i]</C> for
+# all <C>i</C>.
 #
 # <Example><![CDATA[
 # gap> RandomSmallSemigroup(8, IsCommutative, true,

--- a/gap/enums.gi
+++ b/gap/enums.gi
@@ -270,12 +270,12 @@ function(arg...)
     until IsDoneIterator(iter) or Runtime() - t > j;
 
     if IsDoneIterator(iter) and i > 1 then
-      iter := IteratorOfSmallSemigroups(arg);
+      iter := CallFuncList(IteratorOfSmallSemigroups, arg);
       for j in [1 .. RandomList(rs, [1 .. i - 1])] do
         s := NextIterator(iter);
       od;
     elif IsDoneIterator(iter) and i = 1 then  # iterators of length 1
-      iter := IteratorOfSmallSemigroups(arg);
+      iter := CallFuncList(IteratorOfSmallSemigroups, arg);
       s := NextIterator(iter);
     fi;
     return s;

--- a/gap/enums.gi
+++ b/gap/enums.gi
@@ -238,15 +238,21 @@ end);
 
 InstallGlobalFunction(RandomSmallSemigroup,
 function(arg...)
-  local iter, i, j, s, t, enum;
+  local iter, i, j, s, t, enum, rs;
+
+  if Length(arg) >= 1 and IsRandomSource(arg[1]) then
+    rs := Remove(arg, 1);
+  else
+    rs := GlobalMersenneTwister;
+  fi;
 
   if Length(arg) = 1 and IsPosInt(arg[1]) then
-    i := Random(1, NrSmallSemigroups(arg[1]));
+    i := Random(rs, 1, NrSmallSemigroups(arg[1]));
     return SmallSemigroupNC(arg[1], i);
   elif CallFuncList(SMALLSEMI_CanCreateEnumerator, arg) then
     enum := CallFuncList(EnumeratorOfSmallSemigroups, arg);
     if not IsEmpty(enum) then
-      i := Random(1, Length(enum));
+      i := Random(rs, 1, Length(enum));
       return enum[i];
     fi;
     return fail;
@@ -254,7 +260,7 @@ function(arg...)
 
   iter := CallFuncList(IteratorOfSmallSemigroups, arg);
   i := 0;
-  j := Random(1, 500);
+  j := Random(rs, 1, 500);
   t := Runtime();
 
   if not IsDoneIterator(iter) then  # in case of the empty iterator
@@ -265,7 +271,7 @@ function(arg...)
 
     if IsDoneIterator(iter) and i > 1 then
       iter := IteratorOfSmallSemigroups(arg);
-      for j in [1 .. RandomList([1 .. i - 1])] do
+      for j in [1 .. RandomList(rs, [1 .. i - 1])] do
         s := NextIterator(iter);
       od;
     elif IsDoneIterator(iter) and i = 1 then  # iterators of length 1

--- a/gap/enums.gi
+++ b/gap/enums.gi
@@ -241,12 +241,12 @@ function(arg...)
   local iter, i, j, s, t, enum;
 
   if Length(arg) = 1 and IsPosInt(arg[1]) then
-    i := Random(RandomSource(IsMersenneTwister), 1, NrSmallSemigroups(arg[1]));
+    i := Random(1, NrSmallSemigroups(arg[1]));
     return SmallSemigroupNC(arg[1], i);
   elif CallFuncList(SMALLSEMI_CanCreateEnumerator, arg) then
     enum := CallFuncList(EnumeratorOfSmallSemigroups, arg);
     if not IsEmpty(enum) then
-      i := Random(RandomSource(IsMersenneTwister), 1, Length(enum));
+      i := Random(1, Length(enum));
       return enum[i];
     fi;
     return fail;
@@ -254,7 +254,7 @@ function(arg...)
 
   iter := CallFuncList(IteratorOfSmallSemigroups, arg);
   i := 0;
-  j := Random(RandomSource(IsMersenneTwister), 1, 500);
+  j := Random(1, 500);
   t := Runtime();
 
   if not IsDoneIterator(iter) then  # in case of the empty iterator

--- a/tst/enums.tst
+++ b/tst/enums.tst
@@ -219,6 +219,15 @@ gap> s := OneSmallSemigroup(6, IsRectangularBand, true);
 <small semigroup of size 6>
 gap> IsRectangularBand(s);
 true
+gap> RandomSmallSemigroup(8, IsRectangularBand, true,
+> IsCommutative, false,
+> IsInverseSemigroup, false,
+> IsMonogenicSemigroup, false,
+> IsMonoidAsSemigroup, false,
+> IsGroupAsSemigroup, false,
+> IsZeroSemigroup, false,
+> IsZeroSimpleSemigroup, false);
+<small semigroup of size 8>
 gap> enum := EnumeratorOfSmallSemigroups(6, IsCommutative, false);
 <enumerator of semigroups of size 6>
 gap> enum := EnumeratorOfSmallSemigroups(enum, DiagonalOfMultiplicationTable,

--- a/tst/enums.tst
+++ b/tst/enums.tst
@@ -208,7 +208,8 @@ gap> IsSimpleSemigroup(s);
 true
 gap> IsCompletelySimpleSemigroup(s);
 true
-gap> s := RandomSmallSemigroup(8, IsSimpleSemigroup, true);
+gap> rs := GlobalMersenneTwister;;
+gap> s := RandomSmallSemigroup(rs, 8, IsSimpleSemigroup, true);
 <small semigroup of size 8>
 gap> IsSimpleSemigroup(s);
 true

--- a/tst/enums.tst
+++ b/tst/enums.tst
@@ -228,6 +228,16 @@ gap> RandomSmallSemigroup(8, IsRectangularBand, true,
 > IsZeroSemigroup, false,
 > IsZeroSimpleSemigroup, false);
 <small semigroup of size 8>
+gap> IdSmallSemigroup(RandomSmallSemigroup(8, IsRectangularBand, true,
+> IsCommutative, false,
+> IsInverseSemigroup, false,
+> IsMonogenicSemigroup, false,
+> IsMonoidAsSemigroup, false,
+> IsGroupAsSemigroup, false,
+> IsZeroSemigroup, false,
+> IsZeroSimpleSemigroup, false,
+> IsLeftZeroSemigroup, true)) = [8, 11422092];
+true
 gap> enum := EnumeratorOfSmallSemigroups(6, IsCommutative, false);
 <enumerator of semigroups of size 6>
 gap> enum := EnumeratorOfSmallSemigroups(enum, DiagonalOfMultiplicationTable,

--- a/tst/smallsemi02.tst
+++ b/tst/smallsemi02.tst
@@ -582,7 +582,7 @@ gap> enum := EnumeratorOfSmallSemigroupsByIds(7, [1 .. 1000]);
 gap> enum := EnumeratorOfSmallSemigroupsByIds([2, 3], [[1 .. 2], [1 .. 10]]);
 <enumerator of semigroups of sizes [ 2, 3 ]>
 
-# doc/../gap/enums.gd:587-593
+# doc/../gap/enums.gd:603-609
 gap> enum := EnumeratorOfSmallSemigroups([2 .. 4], IsSimpleSemigroup, false,
 > IsRegularSemigroup, true);;
 gap> ArgumentsUsedToCreate(enum);
@@ -675,7 +675,7 @@ gap> iter := IteratorOfSmallSemigroups(8, IsCommutative, false);
 gap> OneSmallSemigroup(iter);
 <small semigroup of size 8>
 
-# doc/../gap/enums.gd:606-611
+# doc/../gap/enums.gd:622-627
 gap> enum := EnumeratorOfSmallSemigroups([2 .. 4], IsSimpleSemigroup, true);;
 gap> PositionsOfSmallSemigroupsIn
 > (enum);
@@ -707,7 +707,20 @@ gap> PrecomputedSmallSemisInfo[3];
   "IsSemigroupWithoutClosedIdempotents", "IsSimpleSemigroup",
   "IsSingularSemigroupCopy", "IsZeroSemigroup", "IsZeroSimpleSemigroup" ]
 
-# doc/../gap/enums.gd:548-558
+# doc/../gap/enums.gd:587-592
+gap> enum := EnumeratorOfSmallSemigroups([2 .. 4], IsSimpleSemigroup, false);
+<enumerator of semigroups of sizes [ 2, 3, 4 ]>
+gap> SizesOfSmallSemigroupsIn(enum);
+[ 2, 3, 4 ]
+
+# doc/../gap/enums.gd:645-651
+gap> UpToIsomorphism([SmallSemigroup(5, 126), SmallSemigroup(6, 2)]);
+[ <small semigroup of size 5>, <small semigroup of size 6> ]
+gap> UpToIsomorphism([SmallSemigroup(5, 126), SmallSemigroup(5, 3)]);
+[ <small semigroup of size 5>, <small semigroup of size 5>,
+  <semigroup of size 5, with 5 generators> ]
+
+# doc/../gap/enums.gd:564-574
 gap> RandomSmallSemigroup(8, IsCommutative, true,
 > IsInverseSemigroup, true);
 <small semigroup of size 8>
@@ -717,19 +730,6 @@ gap> iter := IteratorOfSmallSemigroups([1 .. 7]);
 <iterator of semigroups of sizes [ 1 .. 7 ]>
 gap> RandomSmallSemigroup(iter);
 <small semigroup of size 7>
-
-# doc/../gap/enums.gd:571-576
-gap> enum := EnumeratorOfSmallSemigroups([2 .. 4], IsSimpleSemigroup, false);
-<enumerator of semigroups of sizes [ 2, 3, 4 ]>
-gap> SizesOfSmallSemigroupsIn(enum);
-[ 2, 3, 4 ]
-
-# doc/../gap/enums.gd:629-635
-gap> UpToIsomorphism([SmallSemigroup(5, 126), SmallSemigroup(6, 2)]);
-[ <small semigroup of size 5>, <small semigroup of size 6> ]
-gap> UpToIsomorphism([SmallSemigroup(5, 126), SmallSemigroup(5, 3)]);
-[ <small semigroup of size 5>, <small semigroup of size 5>,
-  <semigroup of size 5, with 5 generators> ]
 
 #
 gap> STOP_TEST("smallsemi02.tst", 1);


### PR DESCRIPTION
There seems to be an issue where RandomSmallSemigroup gives the same semigroup each time. RandomSource defaults to a specific initial seed each time it's called, but removing it seems to make it work!